### PR TITLE
error handling for lustre19/expphy path

### DIFF
--- a/lund_helper.py
+++ b/lund_helper.py
@@ -116,7 +116,8 @@ def Lund_Entry(lund_location, lund_download_dir="lund_dir/"):
                     lund_location = "/"+lund_location
             if lund_location[-1] is not "/":
                     lund_location += "/"
-            lund_location ='/lustre19/expphy'+lund_location
+            if "/lustre19/expphy" not in lund_location: 
+                    lund_location ='/lustre19/expphy'+lund_location
             #print("trying to rsync {}".format(lund_location))
             lund_copy_path = 'gemc@dtn1902-ib:'+lund_location
 

--- a/lund_helper.py
+++ b/lund_helper.py
@@ -119,7 +119,10 @@ def Lund_Entry(lund_location, lund_download_dir="lund_dir/"):
             lund_location ='/lustre19/expphy'+lund_location
             #print("trying to rsync {}".format(lund_location))
             lund_copy_path = 'gemc@dtn1902-ib:'+lund_location
-            subprocess.call(['rsync', '-a', lund_copy_path, lund_download_dir])
+
+            #subprocess.call(['rsync', '-a', lund_copy_path, lund_download_dir])
+            subprocess.call(['rsync', '-zav','--prune-empty-dirs',"--include='*.dat'",
+                    "--include='*.txt'","--exclude='*'",lund_copy_path, lund_download_dir])
 
             files = os.listdir(lund_download_dir)
             for f in files:


### PR DESCRIPTION
now lund_helper still works if the user puts in /lustre19/expphy/volatile/ or just /volatile/